### PR TITLE
feat: Services に kiiten / kawarin / maplescouter を追加

### DIFF
--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -2,6 +2,9 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 
 const services = [
+  { name: 'kiiten', desc: 'メイプルストーリー（JMS）の攻略ツール集', href: 'https://kiiten.com' },
+  { name: 'kawarin', desc: 'ノードグラフで組み立てる、ゲーム向け画面操作の自動化ツール', href: 'https://kawarin.cc' },
+  { name: 'maplescouter', desc: 'ゲーム画面の OCR で経験値と狩り効率をリアルタイム表示する外部ツール', href: 'https://scouter.kiiten.com' },
   { name: 'expires', desc: 'API Key / Token の失効を管理する台帳サービス', href: 'https://expires.live' },
   { name: 'evalytics', desc: 'Google Meet を AI が講評する Chrome 拡張＋紹介サイト', href: 'https://evalytics.work' },
   { name: 'travellers-rest-advisor', desc: "Traveller's Rest の酒場運営を支援するレシピ計算ツール", href: 'https://travellers-rest-advisor.pages.dev' },


### PR DESCRIPTION
## 変更内容

`src/pages/services.astro` の稼働中サービス一覧に 3 件を追加しました。

| name | URL | 説明 |
|---|---|---|
| kiiten | https://kiiten.com | メイプルストーリー（JMS）の攻略ツール集 |
| kawarin | https://kawarin.cc | ノードグラフで組み立てる、ゲーム向け画面操作の自動化ツール |
| maplescouter | https://scouter.kiiten.com | ゲーム画面の OCR で経験値と狩り効率をリアルタイム表示する外部ツール |

既存の expires / evalytics / travellers-rest-advisor はそのまま、新規 3 件を先頭に並べています。

## なぜ

稼働中のサービスが一覧に反映されていなかったため。

## レビュー時に見てほしい点

- **並び順**: 新規 3 件を先頭にしています。既存を先頭に戻すべきなら入れ替えます。
- **配置ページ**: kawarin と maplescouter は Web サービスというよりデスクトップツール＋紹介サイトです。稼働中の公開サイトがあるので Services に入れましたが、Tools ページの方が適切なら移せます。
- URL と説明は各プロジェクトのローカル README およびサイト内の canonical から取得しています。
- eromani は元々このリポジトリのどのページにも記載がないため、非公開のまま変更していません。

## 確認

- `npm run build` 成功（15 ページ生成）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
