### PR TITLE
docs: プロフィール README の GitHub Stats を刷新

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,17 @@ Pinned repositories are either OSS that I have contributed to or OSS that I have
 
 Please have a look.
 
-[![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=tanmen&theme=dark)](https://github.com/anuraghazra/github-readme-stats)
+## 📊 GitHub Stats
 
+<p align="center">
+  <img height="180" alt="Tanmen's GitHub stats" src="https://github-stats-extended.vercel.app/api?username=tanmen&show_icons=true&include_all_commits=true&rank_icon=github&hide_border=true&bg_color=05060a&title_color=2ee6ff&text_color=cfe9ff&icon_color=ff2e88&ring_color=7b5cff" />
+  <img height="180" alt="Top languages" src="https://github-stats-extended.vercel.app/api/top-langs/?username=tanmen&layout=compact&langs_count=8&hide_border=true&bg_color=05060a&title_color=2ee6ff&text_color=cfe9ff" />
+</p>
+
+<p align="center">
+  <img height="180" alt="GitHub streak" src="https://streak-stats.demolab.com?user=tanmen&hide_border=true&background=05060a&stroke=1f2937&ring=2ee6ff&fire=ff2e88&currStreakNum=cfe9ff&sideNums=cfe9ff&currStreakLabel=2ee6ff&sideLabels=7c8aa0&dates=4a5568" />
+</p>
+
+<p align="center">
+  <img alt="Contribution activity graph" src="https://github-readme-activity-graph.vercel.app/graph?username=tanmen&hide_border=true&area=true&bg_color=05060a&color=cfe9ff&line=2ee6ff&point=ff2e88&area_color=7b5cff&title_color=2ee6ff" />
+</p>


### PR DESCRIPTION
## 何をしたか

プロフィール README（このリポジトリの `README.md`）に表示している GitHub Stats のカードを差し替え・追加した。

| カード | 提供元 | 状態 |
| --- | --- | --- |
| GitHub Stats（ランク付き） | github-stats-extended | 追加 |
| Most Used Languages | github-stats-extended | 移行 |
| Streak | streak-stats.demolab.com | 追加 |
| Contribution Activity Graph | github-readme-activity-graph | 追加 |

## なぜ

これまで使っていた `github-readme-stats.vercel.app` が **503 を返して停止**しており、README 上でカードが表示されなくなっていた。

本家 `anuraghazra/github-readme-stats` はリポジトリの archived フラグこそ立っていないものの、事実上メンテナンスされておらず、公式に後継として案内されているのが [stats-organization/github-stats-extended](https://github.com/stats-organization/github-stats-extended)。パラメータ完全互換でドメインを変えるだけで移行できるため、これを採用した。

## レビュアー向けメモ

- 4 枚とも実際にエンドポイントを叩き、**200 + SVG が返ること、指定したカスタムカラーが SVG 内に反映されていること**を確認済み。
- 配色はプリセットテーマではなく、サイト本体の配色（背景 `#05060a` / 見出し `#2ee6ff` / アイコン `#ff2e88` / リング・エリア `#7b5cff` / 本文 `#cfe9ff`）に合わせたカスタム指定。サイトとプロフィールで統一感を出す狙い。
- `github-profile-trophy` も候補に入れたが、**402 Payment Required**（Vercel 側の課金停止）で死んでいたため見送った。
- 外部サービス依存なので、将来また同様に停止するリスクはある。その場合はドメイン差し替えで対応可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
