### PR TITLE
ci: dependabot PR を Kodiak で自動マージする

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+    # まとめた PR の本文には各依存の "from X to Y" が残るため、
+    # Kodiak はグループ内で最大の更新種別を見て自動マージを判定する。
+    groups:
+      astro:
+        patterns:
+          - astro
+          - "@astrojs/*"
+      react:
+        patterns:
+          - react
+          - react-dom
+          - "@types/react"
+          - "@types/react-dom"
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    commit-message:
+      prefix: ci
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm check
+
+      - run: pnpm build

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,0 +1,17 @@
+# Kodiak 設定 — https://kodiakhq.com/docs/config-reference
+version = 1
+
+[merge]
+# 通常の PR は、このラベルが付いたときだけ Kodiak がマージする
+automerge_label = "automerge"
+# 既存履歴に合わせてマージコミット（1 コミットにまとめたいなら "squash"）
+method = "merge"
+delete_branch_on_merge = true
+
+# 依存更新 PR はラベル不要で自動マージする。
+# minor / patch のみ対象で、major は手動レビューに残す。
+# グループ化された PR は本文中の "from X to Y" をすべて見て
+# 最大の更新種別が採用されるため、major を含むグループは自動マージされない。
+[merge.automerge_dependencies]
+versions = ["minor", "patch"]
+usernames = ["dependabot", "dependabot[bot]"]


### PR DESCRIPTION
## 目的

dependabot の依存更新 PR を手動で捌かずに済むよう、Kodiak による自動マージを導入する。
あわせて、自動マージの前提となる CI（`pnpm check` / `pnpm build`）が無かったので新設する。

## 変更内容

### `.kodiak.toml`（新規）

- 通常の PR は `automerge` ラベルが付いたときだけ Kodiak がマージする
- dependabot の **minor / patch のみラベル不要で自動マージ**。major は手動レビューに残す
- マージ方式は既存履歴に合わせてマージコミット。マージ後にブランチを削除する

グループ化された dependabot PR について、Kodiak は本文中の `from X to Y` 行をすべて走査して
**最大の更新種別**を採用する（`bot/kodiak/dependencies.py` の `dep_versions_from_dependabot_pr_body`）。
そのため major を含むグループは自動マージされない。

### `.github/dependabot.yml`（新規）

- npm / github-actions を毎週月曜 9:00 (JST) に更新
- astro 系・react 系・minor+patch をグループ化して PR 数を抑える
- npm は同時 5 PR まで

### `.github/workflows/ci.yml`（新規）

- PR と master への push で `pnpm install --frozen-lockfile` → `pnpm check` → `pnpm build`
- Node バージョンは `.node-version`、pnpm は `packageManager` フィールドから解決
- ジョブ名 `build` をブランチ保護の必須チェックにする

## レビュー時に見てほしい点

ローカルで `pnpm install --frozen-lockfile` → `pnpm check`（0 errors）→ `pnpm build`（15 ページ生成）が
通ることは確認済み。

## マージ後に必要な手動作業

1. **Kodiak GitHub App のインストール** — https://github.com/marketplace/kodiakhq （public リポジトリは無料）
2. **`master` のブランチ保護を有効化** — 必須チェック `build`、レビュー必須は **無効のまま**にする
   （レビュー必須にすると dependabot PR が承認されず自動マージが止まるため）
3. **Gatsby 時代の古い dependabot PR (#40〜#48) のクローズ** — patch 判定されるため
   Kodiak の自動マージ対象に入ってしまう
